### PR TITLE
ログイン、ログアウトでヘッダーの表示が変更する機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,7 @@
 @import "modules/purchases";
 @import "modules/purchases-edit";
 @import "modules/purchases-new";
-@import "modules/tops_show";
+@import "modules/products_show";
 @import "modules/devise";
 @import "modules/errorMsgText";
 @import "modules/products_show";

--- a/app/assets/stylesheets/modules/_products_index.scss
+++ b/app/assets/stylesheets/modules/_products_index.scss
@@ -81,7 +81,7 @@
         &__item{
           display: flex;
           line-height: 38px;
-          padding: 0 0 0 16px;
+          padding: 0 16px 0 0;
         }
       }
       .listRight{
@@ -138,7 +138,9 @@
       }
       .contentbtn{
         display: flex;
-        margin: 24px 0 0 0;
+        .test {
+          margin-right: 10px;
+        }
       }
     }
   }

--- a/app/views/products/_head_tmp.html.haml
+++ b/app/views/products/_head_tmp.html.haml
@@ -13,11 +13,17 @@
     .header-contena__nav
       %ul.listLeft
         %li.listLeft__item.fastCategory
-          = link_to "カテゴリー", 'www', {class: 'link-text'}
+          = link_to "カテゴリー", '#', {class: 'link-text'}
         %li.listLeft__item
-          = link_to "ブランド", 'www', {class: 'link-text'}
+          = link_to "ブランド", '#', {class: 'link-text'}
       %ul.listRight
-        %li.listRight__login
-          = link_to "ログイン", 'www', {class: 'link-text'}
-        %li.listRight__new
-          = link_to "新規会員登録", 'www', {class: 'link-text'}
+        - if user_signed_in?
+          %li.listRight__login
+            = link_to "マイページ", '#', {class: 'link-text'}
+        - else
+          %li.listRight__new
+            = link_to "ログイン", new_user_session_path, {class: 'link-text'}
+          %li.listRight__new
+            = link_to "新規会員登録", new_user_registration_path, {class: 'link-text'}
+          
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
     get 'addresses', to: 'users/registrations#new_address'
     post 'addresses', to: 'users/registrations#create_address'
   end
-  root 'items#index'
   resources :purchases, only: [:index, :new]
   get 'purchases/edit', to: 'purchases#edit'
   resources :tops, only: :show


### PR DESCRIPTION
#What
- ログイン、ログアウトでヘッダーの表示が変更する機能。
- ログイン時にはヘッダーにマイページへ飛ぶボタンを表示し、ログアウト時には新規登録、ログインボタンを表示する。

ヘッダーのpaddingがずれていたので

#Why
- ログイン時とログアウト時で必要な機能が違うため。