### PR TITLE
【WIP】activehashの追加

### DIFF
--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -58,7 +58,7 @@
                 = @address.errors.messages[:postcode][0]
 
           %section.field
-            = f.label :prefecture_id, "都道府県",class: "field--name"
+            = f.collection_select :shipping_id, Shipping.all, :id, :name, {include_blank: "選択してください"}, {class: 'field--name'}
             %span.field--required 必須
             %br/
             .input


### PR DESCRIPTION
# what
ユーザ登録画面で都道府県をアクティブハッシュを使いプルダウンで表示

# why
ユーザが入力せず選択式にすることでユーザの誤入力を防ぐとともに
DBでの管理を簡潔にするため