### PR TITLE
商品詳細表示 機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/_products_show.scss
+++ b/app/assets/stylesheets/modules/_products_show.scss
@@ -272,28 +272,3 @@ $common-color: #3CCACE;
     }
   }
 }
-
-.not-found {
-  background-color: #fff;
-  margin: 60px auto 60px;
-  width: 700px;
-  .error {
-    padding: 80px 160px;
-    text-align: center;
-    &__text {
-      font-size: 24px;
-      font-weight: bold;
-      padding-bottom: 20px;
-    }
-    &__msg {
-      padding-bottom: 30px;
-    }
-    &__image {
-      display: block;
-      justify-content: center;
-      &--logo {
-        width: 300px;
-      }
-    }
-  }
-}

--- a/app/assets/stylesheets/modules/_products_show.scss
+++ b/app/assets/stylesheets/modules/_products_show.scss
@@ -1,13 +1,5 @@
 $common-color: #3CCACE;
 
-.top-area {
-  height: 97px;
-}
-.select-area {
-  border-top: 1px solid #eee;
-  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
-  height: 55px;
-}
 .show-wrapper {
   background-color: #f8f8f8;
   .show-main{
@@ -50,7 +42,6 @@ $common-color: #3CCACE;
                   li {
                     width: 25%;
                     margin: 0 10px 0 0;
-                    // margin-right: 10px;
                     img {
                       object-fit: cover;
                       height: 87px;
@@ -72,7 +63,19 @@ $common-color: #3CCACE;
               font-size: 16px;
             }
           }
+          &__purchase {
+            display: block;
+            margin-top: 16px;
+            background-color: $common-color;
+            font-size: 24px;
+            line-height: 60px;
+            text-align: center;
+            font-weight: 600;
+            text-decoration: none;
+            color: #fff;
+          }
           &__description {
+            padding-top: 32px;
             line-height: 1.5;
             font-size: 18px;
             margin-bottom: 30px;
@@ -170,6 +173,31 @@ $common-color: #3CCACE;
             text-align: left;
           }
         }
+        .edit-box {
+          background-color: #fff;
+          padding: 8px 16px;
+          margin: 24px 0;
+          text-align: center;
+          a {
+            display: block;
+            margin: 16px 0;
+            border: 1px solid $common-color;
+            font-size: 14px;
+            line-height: 48px;
+            width: 100%;
+            border-radius: 4px;
+            text-decoration: none;
+            background-color: $common-color;
+            color: #fff;
+          }
+          p {
+            font-size: 16px;
+          }
+          #delete {
+            background-color: #aaa;
+            border: 1px solid #aaa;
+          }
+        }
       }
     }
     .links {
@@ -245,11 +273,27 @@ $common-color: #3CCACE;
   }
 }
 
-.app-banner {
-  height: 359px;
-}
-
-.footer {
-  background-color: #272727;
-  height: 354px;
+.not-found {
+  background-color: #fff;
+  margin: 60px auto 60px;
+  width: 700px;
+  .error {
+    padding: 80px 160px;
+    text-align: center;
+    &__text {
+      font-size: 24px;
+      font-weight: bold;
+      padding-bottom: 20px;
+    }
+    &__msg {
+      padding-bottom: 30px;
+    }
+    &__image {
+      display: block;
+      justify-content: center;
+      &--logo {
+        width: 300px;
+      }
+    }
+  }
 }

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,2 +1,12 @@
 class MypagesController < ApplicationController
+
+  def show
+    if user_signed_in?
+      @selected_product = Product.includes(:images).find(params[:id])
+      @categories = Category.all
+    else
+      redirect_to new_user_session_path
+    end
+  end
+
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -57,7 +57,7 @@ class ProductsController < ApplicationController
   private
 
   def product_params
-    params.require(:product).permit(:name, :detail, :price, :status_id, :prefecture_id, :category_id, :shippingcost_id, :shipping_id, brand_attributes: [:id, :name], images_attributes: [:image, :_destroy, :id])
+    params.require(:product).permit(:name, :detail, :price, :status_id, :prefecture_id, :category_id, :shippingcost_id, :shipping_id, brand_attributes: [:id, :name], images_attributes: [:image, :_destroy, :id]).merge(saler_id: current_user.id)
   end
 
   def set_product

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,5 @@
 class Product < ApplicationRecord
-  # belongs_to :saler, class_name: "User"
-  # belongs_to :buyer, class_name: "User"
+  belongs_to :saler, class_name: "User"
   belongs_to :category
   has_many :images
   has_one :brand

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :email, format: { with:  /\A\S+@\S+\.\S+\z/}
   has_one :identification
   has_one :address
+  has_many :products
 end 

--- a/app/views/mypages/show.html.haml
+++ b/app/views/mypages/show.html.haml
@@ -1,0 +1,96 @@
+.show-top
+  = render 'products/head_tmp'
+
+- if current_user.id == @selected_product.saler_id
+  .show-wrapper
+    .show-main
+      .contents
+        .top-content
+          .product
+            %h2.product__name
+              = @selected_product.name
+            .product__body
+              %ul
+                %li
+                  = image_tag @selected_product.images[0].image.url
+                  %ul
+                    - @selected_product.images.each_with_index do |productimage|
+                      %li
+                        = image_tag productimage.image.url
+            .product__price
+              %span
+                ¥
+                = @selected_product.price
+              .product__price--detail
+                (税込)送料込み
+            .product__description
+              = @selected_product.detail
+            .table
+              %table
+                %tbody
+                  %tr
+                    %th 出品者
+                    %td hoge
+                  %tr
+                    %th カテゴリー
+                    %td
+                      - @categories.each do |grandchildren|
+                        - if @selected_product.category_id == grandchildren.id
+                          = link_to category_path(grandchildren.parent.parent.id) do
+                            = grandchildren.parent.parent.name
+                            %br
+                          = link_to category_path(grandchildren.parent.id) do
+                            = grandchildren.parent.name
+                            %br
+                          = link_to category_path(grandchildren.id) do
+                            = grandchildren.name
+                            %br
+                  %tr
+                    %th ブランド
+                    %td
+                      = @selected_product.brand.name
+                  %tr
+                    %th 商品のサイズ
+                    %td
+                  %tr
+                    %th 商品の状態
+                    %td
+                      = @selected_product.status.name
+                  %tr
+                    %th 配送料の負担
+                    %td
+                      = @selected_product.shippingcost.name
+                  %tr
+                    %th 発送元の地域
+                    %td
+                      = link_to @selected_product.prefecture.name, "#"
+                  %tr
+                    %th 発送日の目安
+                    %td
+                      = @selected_product.shipping.name
+          .edit-box
+            = link_to '商品の編集', "#"
+            %p
+              or
+            = link_to 'この商品を削除する', "#", id: "delete"
+          .comment-box
+            = form_with url: '#', class: "comment-box__new", method: :get, local: true do |form|
+              = form.text_area :comment, class: "comment-box__new--body"
+              %p.notice-msg
+                相手のことを考え丁寧なコメントを心がけましょう。<br>不快な言葉遣いなどは利用制限や退会処分となることがあります。
+              = button_tag type: 'submit', class: "comment-box__new--btn" do
+                = icon('fa', 'comment')
+                = "コメントする"
+  = render 'products/footer_tmp'
+
+- else
+  .not-found
+    .error
+      %h1.error__text
+        ページが見つかりませんでした。
+      %p.error__msg
+        お探しのページはアドレスが間違っているか、<br>
+        削除された可能性があります。
+      .error__image
+        = image_tag 'material/logo/logo.png', alt: "FURIMA画像", class: "error__image--logo"
+  = render 'products/footer_tmp'

--- a/app/views/mypages/show.html.haml
+++ b/app/views/mypages/show.html.haml
@@ -1,96 +1,85 @@
 .show-top
   = render 'products/head_tmp'
 
-- if current_user.id == @selected_product.saler_id
-  .show-wrapper
-    .show-main
-      .contents
-        .top-content
-          .product
-            %h2.product__name
-              = @selected_product.name
-            .product__body
-              %ul
-                %li
-                  = image_tag @selected_product.images[0].image.url
-                  %ul
-                    - @selected_product.images.each_with_index do |productimage|
-                      %li
-                        = image_tag productimage.image.url
-            .product__price
-              %span
-                ¥
-                = @selected_product.price
-              .product__price--detail
-                (税込)送料込み
-            .product__description
-              = @selected_product.detail
-            .table
-              %table
-                %tbody
-                  %tr
-                    %th 出品者
-                    %td hoge
-                  %tr
-                    %th カテゴリー
-                    %td
-                      - @categories.each do |grandchildren|
-                        - if @selected_product.category_id == grandchildren.id
-                          = link_to category_path(grandchildren.parent.parent.id) do
-                            = grandchildren.parent.parent.name
-                            %br
-                          = link_to category_path(grandchildren.parent.id) do
-                            = grandchildren.parent.name
-                            %br
-                          = link_to category_path(grandchildren.id) do
-                            = grandchildren.name
-                            %br
-                  %tr
-                    %th ブランド
-                    %td
-                      = @selected_product.brand.name
-                  %tr
-                    %th 商品のサイズ
-                    %td
-                  %tr
-                    %th 商品の状態
-                    %td
-                      = @selected_product.status.name
-                  %tr
-                    %th 配送料の負担
-                    %td
-                      = @selected_product.shippingcost.name
-                  %tr
-                    %th 発送元の地域
-                    %td
-                      = link_to @selected_product.prefecture.name, "#"
-                  %tr
-                    %th 発送日の目安
-                    %td
-                      = @selected_product.shipping.name
+.show-wrapper
+  .show-main
+    .contents
+      .top-content
+        .product
+          %h2.product__name
+            = @selected_product.name
+          .product__body
+            %ul
+              %li
+                = image_tag @selected_product.images[0].image.url
+                %ul
+                  - @selected_product.images.each_with_index do |productimage|
+                    %li
+                      = image_tag productimage.image.url
+          .product__price
+            %span
+              ¥
+              = @selected_product.price
+            .product__price--detail
+              (税込)送料込み
+          .product__description
+            = @selected_product.detail
+          .table
+            %table
+              %tbody
+                %tr
+                  %th 出品者
+                  %td
+                    = @selected_product.saler.nickname
+                %tr
+                  %th カテゴリー
+                  %td
+                    - @categories.each do |grandchildren|
+                      - if @selected_product.category_id == grandchildren.id
+                        = link_to category_path(grandchildren.parent.parent.id) do
+                          = grandchildren.parent.parent.name
+                          %br
+                        = link_to category_path(grandchildren.parent.id) do
+                          = grandchildren.parent.name
+                          %br
+                        = link_to category_path(grandchildren.id) do
+                          = grandchildren.name
+                          %br
+                %tr
+                  %th ブランド
+                  %td
+                    = @selected_product.brand.name
+                %tr
+                  %th 商品のサイズ
+                  %td
+                %tr
+                  %th 商品の状態
+                  %td
+                    = @selected_product.status.name
+                %tr
+                  %th 配送料の負担
+                  %td
+                    = @selected_product.shippingcost.name
+                %tr
+                  %th 発送元の地域
+                  %td
+                    = link_to @selected_product.prefecture.name, "#"
+                %tr
+                  %th 発送日の目安
+                  %td
+                    = @selected_product.shipping.name
+        - if current_user.present? && current_user.id == @selected_product.saler_id
           .edit-box
             = link_to '商品の編集', "#"
             %p
               or
             = link_to 'この商品を削除する', "#", id: "delete"
-          .comment-box
-            = form_with url: '#', class: "comment-box__new", method: :get, local: true do |form|
-              = form.text_area :comment, class: "comment-box__new--body"
-              %p.notice-msg
-                相手のことを考え丁寧なコメントを心がけましょう。<br>不快な言葉遣いなどは利用制限や退会処分となることがあります。
-              = button_tag type: 'submit', class: "comment-box__new--btn" do
-                = icon('fa', 'comment')
-                = "コメントする"
-  = render 'products/footer_tmp'
-
-- else
-  .not-found
-    .error
-      %h1.error__text
-        ページが見つかりませんでした。
-      %p.error__msg
-        お探しのページはアドレスが間違っているか、<br>
-        削除された可能性があります。
-      .error__image
-        = image_tag 'material/logo/logo.png', alt: "FURIMA画像", class: "error__image--logo"
-  = render 'products/footer_tmp'
+        .comment-box
+          = form_with url: '#', class: "comment-box__new", method: :get, local: true do |form|
+            = form.text_area :comment, class: "comment-box__new--body"
+            %p.notice-msg
+              相手のことを考え丁寧なコメントを心がけましょう。<br>不快な言葉遣いなどは利用制限や退会処分となることがあります。
+            = button_tag type: 'submit', class: "comment-box__new--btn" do
+              = icon('fa', 'comment')
+              = "コメントする"
+= render 'products/footer_tmp'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -22,6 +22,13 @@
               = @selected_product.price
             .product__price--detail
               (税込)送料込み
+          - if current_user.present? && current_user.id != @selected_product.saler_id
+            = link_to purchases_path, class: "product__purchase" do
+              = "購入画面に進む"
+          - elsif current_user.present? && current_user.id == @selected_product.saler_id
+          - else
+            = link_to new_user_session_path, class: "product__purchase" do
+              = "購入画面に進む"
           .product__description
             = @selected_product.detail
           .table
@@ -29,7 +36,8 @@
               %tbody
                 %tr
                   %th 出品者
-                  %td hoge
+                  %td
+                    = @selected_product.saler.nickname
                 %tr
                   %th カテゴリー
                   %td
@@ -97,7 +105,9 @@
               = "後の商品"
             = icon('fa', 'angle-right')
       .related-items
-        = link_to 'ベビー・キッズをもっと見る', "#"
+        = link_to '#' do
+          = @selected_product.saler.nickname
+          さんのその他の出品
         .related-items__lists
           .related-items__lists__product
             = link_to "#" do
@@ -114,5 +124,4 @@
                       1
                   %p
                     （税込）
-.app-banner
-.footer
+  = render 'footer_tmp'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'mypages', to:'mypages#index'
+  resources :mypages, only: [:index, :show]
   get 'users', to: 'users#logout'
   
   resources :categories, only: [:show]


### PR DESCRIPTION
# What
 - 商品詳細ページから商品購入ページへのリンクを実装
    - 出品者以外にしか商品購入ページへのリンクは踏めない
    - ログインしていない場合はログイン画面に遷移
 - 出品者が出品した商品の詳細を確認できるページを実装
    - 編集・削除のリンクは出品者にしか踏めない
    - ログインしていない場合はログイン画面に遷移

# Why
商品詳細ページから商品購入ページに遷移できるようにするため。
出品した商品の詳細を確認できるようにするため。