### PR TITLE
jQueryエラーの解消

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,3 @@
-//= require rails-ujs
 //= require turbolinks
 //= require jquery
 //= require jquery_ujs


### PR DESCRIPTION
# What
application.jsから以下の1行を削除
```
//= require rails-ujs
```
# Why
以下のエラー解消のため
```
If you load both jquery_ujs and rails-ujs, use rails-ujs only.
```
<img width="1440" alt="you load both jquery_ujs and rails-ujs, use rails-ujs only" src="https://user-images.githubusercontent.com/65227841/99140298-ec2ee680-2683-11eb-87f7-6c7dc66cfa22.png">
