### PR TITLE
トップページから出品ページへのパスの追加

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(function() {
+$(document).on('turbolinks:load',function() {
   // 子カテゴリーにてoptionタグの作成
   function appendOption(category) {
     let html = 

--- a/app/views/products/_footer_tmp.html.haml
+++ b/app/views/products/_footer_tmp.html.haml
@@ -37,7 +37,7 @@
   .footer__logo
     = link_to image_tag("material/logo/logo-white.png",width: '160',  height: '46.34', alt: "サンプル画像"), 'www', {class: 'test3'}
   %p © FURIMA
-= link_to root_path do
+= link_to new_product_path do
   .cameraBtn
     %span.cameraBtn__text 出品する
     = image_tag 'material/icon/icon_camera.png', width: '54', height: '54' ,alt: 'test',  class: 'test'


### PR DESCRIPTION
# What
- 出品ボタンのパスをnew_product_pathに変更
- category.jsが遷移後に動くようにturbolinksの無効化

# Why
- トップページから出品ページへ遷移するため
- 遷移後リロードしなくてもcategory.jsが動くようにするため