### PR TITLE
マイページから商品編集ページへ遷移するパスの追加

### DIFF
--- a/app/assets/stylesheets/modules/_mypages_index.scss
+++ b/app/assets/stylesheets/modules/_mypages_index.scss
@@ -48,6 +48,7 @@
   width: 700px;
   .main-box {
     position: relative;
+    font-size: 0;
     .user {
       position: absolute;
       top: 50%;
@@ -120,6 +121,8 @@
         display: flex;
         justify-content: space-between;
         padding: 10px;
+        text-decoration: none;
+        color: #333333;
         .product-item {
           display: flex;
           .produit-details {

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -26,7 +26,7 @@
         .menu__list.active
           #about.menu__item 過去の取引商品
         .menu__list
-          #about.menu__item 出品中の商品
+          #about.menu__item 出品した商品
       .menu__product
         .display.products_info.second-display
           -if @buyer.length == 0
@@ -35,7 +35,7 @@
               過去の取引はありません
           -else 
             - @buyer.each do |test|
-              %li.saler-product
+              = link_to product_path(test.id), class: "saler-product" do
                 .product-item
                   = image_tag test.images[0].image.url, size: "50x50"
                   .produit-details
@@ -52,14 +52,18 @@
               出品中の商品はありません
           -else 
             - @saler.each do |test|
-              %li.saler-product
+              = link_to edit_product_path(test.id), class: "saler-product" do
                 .product-item
                   = image_tag test.images[0].image.url, size: "50x50"
                   .produit-details
                     %p.name
                       = test.name;
-                    .mypage-item-status
-                      出品中
+                    -if test.buyer_id.blank?
+                      .mypage-item-status
+                        出品中
+                    -else
+                      .mypage-item-status
+                        取引完了
                 .menu-myitem__right
                   = icon("fas", "chevron-right")     
 =render partial: "products/footer_tmp"


### PR DESCRIPTION
# What
- 出品した商品から商品編集ページへ遷移するパスの追加
- 過去の取引商品から商品詳細ページへ遷移するパスの追加

#Why
- マイページから商品の編集を行うため